### PR TITLE
config: allow reading externalIPs from files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,32 +14,17 @@
 # 8333  Mainnet Bitcoin peer-to-peer port
 # 8334  Mainet RPC port
 
-ARG ARCH=amd64
-# using the SHA256 instead of tags
-# https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
-# https://cloud.google.com/architecture/using-container-images
-# https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
-# ➜  ~ crane digest golang:1.17.13-alpine3.16
-# sha256:c80567372be0d486766593cc722d3401038e2f150a0f6c5c719caa63afb4026a
-FROM golang@sha256:c80567372be0d486766593cc722d3401038e2f150a0f6c5c719caa63afb4026a AS build-container
+FROM golang:alpine AS build-container
 
-ARG ARCH
 ENV GO111MODULE=on
 
 ADD . /app
 WORKDIR /app
-RUN set -ex \
-  && if [ "${ARCH}" = "amd64" ]; then export GOARCH=amd64; fi \
-  && if [ "${ARCH}" = "arm32v7" ]; then export GOARCH=arm; fi \
-  && if [ "${ARCH}" = "arm64v8" ]; then export GOARCH=arm64; fi \
-  && echo "Compiling for $GOARCH" \
-  && go install -v . ./cmd/...
+RUN go install -v . ./cmd/...
 
-FROM $ARCH/alpine:3.12
+FROM alpine:latest
 
 COPY --from=build-container /go/bin /bin
-
-VOLUME ["/root/.btcd"]
 
 EXPOSE 8333 8334
 


### PR DESCRIPTION
Tor hidden services dumps the onion hostname into a file on disk. If Tor and btcd is started together -- for example in a sidecar pattern -- the onion address is not known before executions.

This allows the user to provide --externalip a path to a file containing any hostname, for example the onion address as dumped by the Tor service.